### PR TITLE
Add Guardian OFM Awards 2011 Cheap Eats post

### DIFF
--- a/_posts/2011-10-16-guardian-ofm-awards-cheap-eats.md
+++ b/_posts/2011-10-16-guardian-ofm-awards-cheap-eats.md
@@ -1,0 +1,9 @@
+---
+title: OFM Awards 2011 - Cheap Eats
+subtitle: The Guardian
+metaTitle: This & That featured in The Guardian's OFM Awards 2011 cheap eats roundup
+---
+
+**"This & That A family-run business established for over 20 years, the exceptionally well-priced menu (£4.40 for two meat dishes, one veg and rice) ensure this remains one of Manchester's most popular curry houses. 3 Soap Street, Shudehill, Manchester M4 1EW; 0161 832 4971"**
+
+**[Source](https://www.theguardian.com/lifeandstyle/2011/oct/16/ofm-awards-2011-cheap-eats-koya)**


### PR DESCRIPTION
## Summary
- Adds a new blog post highlighting This & That's feature in The Guardian's OFM Awards 2011 cheap eats roundup
- Showcases the affordability and popularity of This & That curry house in Manchester

## Changes

### Content Addition
- Created a new markdown post `_posts/2011-10-16-guardian-ofm-awards-cheap-eats.md`
- Included details about the menu pricing and location
- Added a source link to The Guardian article

## Test plan
- [x] Verify the new post renders correctly on the site
- [x] Confirm the metadata (title, subtitle, metaTitle) appears as expected
- [x] Check the source link directs to the correct Guardian article

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/2a351aa0-6add-4cf5-8af1-3698d44c5f04