### PR TITLE
Add The Sun article on Manchester hidden gems

### DIFF
--- a/_posts/2026-01-24-the-sun-manchester-hidden-gems.md
+++ b/_posts/2026-01-24-the-sun-manchester-hidden-gems.md
@@ -1,0 +1,7 @@
+---
+title: Manchester's best hidden gems according to the locals – from great pubs and family-friendly parks to cheap eats
+subtitle: The Sun
+source: https://www.thesun.co.uk/travel/27220906/manchester-hidden-gems-locals-pubs-parks-cheap-eats/
+---
+
+"Rice 'n' Three (a plate topped with rice and three curries) is one of the best lunches in the city and places like This & That and Kabana fight it out for people's favourites."


### PR DESCRIPTION
## Summary
Added a new blog post featuring The Sun's article about Manchester's best hidden gems, including local recommendations for pubs, parks, and affordable dining options.

## Changes
- Created new post file: `_posts/2026-01-24-the-sun-manchester-hidden-gems.md`
- Included article metadata (title, subtitle, source URL)
- Added excerpt highlighting local food recommendations, specifically mentioning Rice 'n' Three and other popular curry establishments

## Details
This post follows the existing blog structure with YAML front matter containing the article title, publication source (The Sun), and a direct link to the original article. The excerpt focuses on the food scene as a key highlight of Manchester's hidden gems.

https://claude.ai/code/session_01WWqNSdzqjpwjL7JFUANmzo