### PR TITLE
Add MFDF Awards 2025 winners article post

### DIFF
--- a/_posts/2025-10-07-the-manc-mfdf-awards-2025.md
+++ b/_posts/2025-10-07-the-manc-mfdf-awards-2025.md
@@ -1,0 +1,20 @@
+---
+title: "The best restaurants and bars in Manchester have been named at the MFDF Awards 2025"
+subtitle: The Manc
+metaTitle: "This & That wins Takeaway of the Year at MFDF Awards 2025"
+source: https://themanc.com/eats/mfdf-awards-2025-winners-manchester/
+---
+
+The winners of this year's Manchester Food and Drink Festival Awards have been named, in a night of celebration of our city's hospitality scene.
+
+The prestigious awards have highlighted 18 winners across Greater Manchester tonight, including the best restaurant, chef, newcomer, bar, and loads more.
+
+In a glittering ceremony held at New Century, hundreds of hospitality insiders gathered together to toast one another and to celebrate another year of brilliant work.
+
+The MFDF Awards, sponsored by Therme Manchester, had a whopping 130 nominees this year, with categories that recognise both the businesses and the talented individuals who shape the region's culinary scene.
+
+> **Takeaway of the Year**
+>
+> WINNER: This & That
+>
+> SHORTLISTED VENUES: Ceresis, Ad Maiora, Home Chinese, Viet Deli, Pancho's Burritos, Rack, Mughli Charcoal Pit


### PR DESCRIPTION
## Summary
Added a new blog post documenting the winners of the Manchester Food and Drink Festival (MFDF) Awards 2025.

## Changes
- Created new post file: `_posts/2025-10-07-the-manc-mfdf-awards-2025.md`
- Includes article from The Manc covering the MFDF Awards 2025 ceremony
- Highlights 18 award winners across Greater Manchester
- Features Takeaway of the Year category with This & That as winner and 7 shortlisted venues

## Details
The post contains:
- Proper front matter with title, subtitle, meta title, and source attribution
- Overview of the awards ceremony and its significance to Manchester's hospitality scene
- Details about the 130 nominees and award categories
- Specific category highlight (Takeaway of the Year) with winner and shortlist

https://claude.ai/code/session_019b9YFejaVgV2ZRPJKJ2m2J